### PR TITLE
adding missing assignment operator

### DIFF
--- a/lib/chef/knife/tidy_server_report.rb
+++ b/lib/chef/knife/tidy_server_report.rb
@@ -99,7 +99,7 @@ class Chef
             action_needed(pre_12_3_message, server_warnings_file_path)
           end
           if unconverged_recent_nodes.length > 0
-            unconverged_recent_message "#{unconverged_recent_nodes.length} nodes have been created in the last hour that have yet to converge in organization #{org}. These nodes WILL NOT be factored in the stale cookbook verisons report. Continuing with the server cleanup will delete cookbooks in-use by these nodes."
+            unconverged_recent_message = "#{unconverged_recent_nodes.length} nodes have been created in the last hour that have yet to converge in organization #{org}. These nodes WILL NOT be factored in the stale cookbook verisons report. Continuing with the server cleanup will delete cookbooks in-use by these nodes."
             ui.warn(unconverged_recent_message)
             action_needed(unconverged_recent_message, server_warnings_file_path)
           end


### PR DESCRIPTION
### Description

This PR corrects the following error:
```
Exception: NoMethodError: undefined method `unconverged_recent_message' for #<Chef::Knife::TidyServerReport:0x00000000045378d0>
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>