### PR TITLE
Fix cookbook_version_from_path failing when the org is named "cookbooks"

### DIFF
--- a/knife-tidy.gemspec
+++ b/knife-tidy.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
   s.name             = "knife-tidy"
   s.version          = KnifeTidy::VERSION
   s.version          = "#{s.version}-pre#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV["TRAVIS"]
-  s.has_rdoc         = true
   s.authors          = ["Jeremy Miller"]
   s.email            = ["jmiller@chef.io"]
   s.summary          = "Report on stale Chef Server nodes and cookbooks and clean up data integrity issues in a knife-ec-backup object based backup"

--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -194,7 +194,7 @@ class Chef
         Dir[::File.join(tidy.backup_path, "organizations/*/cookbooks/chef-sugar*/metadata.rb")].each do |file|
           ui.stdout.puts "INFO: Searching for known chef-sugar problems when uploading."
           s = Chef::TidySubstitutions.new(nil, tidy)
-          version = s.cookbook_version_from_path(file)
+          version = tidy.cookbook_version_from_path(file)
           patterns = [
             {
               search: "^require .*/lib/chef/sugar/version",
@@ -279,9 +279,7 @@ class Chef
 
       def create_minimal_metadata(cookbook_path)
         name = tidy.cookbook_name_from_path(cookbook_path)
-        components = cookbook_path.split(File::SEPARATOR)
-        name_version = components[components.index("cookbooks") + 1]
-        version = name_version.match(/\d+\.\d+\.\d+/).to_s
+        version = tidy.cookbook_version_from_path(cookbook_path)
         metadata = {}
         metadata["name"] = name
         metadata["version"] = version

--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -194,7 +194,7 @@ class Chef
         Dir[::File.join(tidy.backup_path, "organizations/*/cookbooks/chef-sugar*/metadata.rb")].each do |file|
           ui.stdout.puts "INFO: Searching for known chef-sugar problems when uploading."
           s = Chef::TidySubstitutions.new(nil, tidy)
-          version = tidy.cookbook_version_from_path(file)
+          version = tidy.cookbook_version_from_path(::File.dirname(file))
           patterns = [
             {
               search: "^require .*/lib/chef/sugar/version",

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -158,6 +158,21 @@ class Chef
       ::File.basename(path, "-*")
     end
 
+    #
+    # Determine the cookbook version from a path.
+    #
+    # @param [String] path The path of the cookbook.
+    #
+    # @return [String] The version of the cookbook.
+    #
+    # @example
+    # cookbook_version_from_path('/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4') => '5.0.4'
+    #
+    def cookbook_version_from_path(path)
+      ::File.basename(path).match(/\d+\.\d+\.\d+/).to_s
+      name_version.match(/\d+\.\d+\.\d+/).to_s
+    end
+
     def global_user_names
       @global_user_names ||= Dir[::File.join(@backup_path, "users", "*")].map { |dir| ::File.basename(dir, ".json") }
     end

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -172,9 +172,20 @@ class Chef
     #
     # @example
     # cookbook_version_from_path('/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4') => '5.0.4'
+    # cookbook_version_from_path('/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4/recipe/default.rb') => '5.0.4'
+    # cookbook_version_from_path('/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4/files/cookbooks/default.rb') => '5.0.4'
     #
     def cookbook_version_from_path(path)
-      ::File.basename(path).match(/\d+\.\d+\.\d+/).to_s
+      dirs = path.split(File::SEPARATOR)
+
+      until dirs.empty?
+        version_match = dirs[-1].match(/\d+\.\d+\.\d+/)
+        if dirs[-2] == "cookbooks" && version_match # we found the cookbook version not something that looks like one inside a cookbook path
+          return version_match.to_s
+        else
+          dirs.pop
+        end
+      end
     end
 
     def global_user_names

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -12,11 +12,15 @@ class Chef
       @backup_path = ::File.expand_path(backup_path)
     end
 
+    #
+    # @return [Chef::Knife::UI]
+    #
     def ui
       @ui ||= Chef::Knife::UI.new(STDOUT, STDERR, STDIN, {})
     end
 
     # The path to the users directory in the backup
+    #
     # @return [String]
     #
     def users_path
@@ -121,6 +125,7 @@ class Chef
       ::File.expand_path(::File.join(@backup_path, "organizations", org))
     end
 
+    # generate a bogus, but valid email
     #
     # @return [String]
     #

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -175,7 +175,6 @@ class Chef
     #
     def cookbook_version_from_path(path)
       ::File.basename(path).match(/\d+\.\d+\.\d+/).to_s
-      name_version.match(/\d+\.\d+\.\d+/).to_s
     end
 
     def global_user_names

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -16,50 +16,114 @@ class Chef
       @ui ||= Chef::Knife::UI.new(STDOUT, STDERR, STDIN, {})
     end
 
+    # The path to the users directory in the backup
+    # @return [String]
+    #
     def users_path
       @users_path ||= ::File.expand_path(::File.join(@backup_path, "users"))
     end
 
+    # The path to the members.json file in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def members_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org, "members.json"))
     end
 
+    # The path to the invitations.json file in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def invitations_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org, "invitations.json"))
     end
 
+    # The path to the clients directory in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def clients_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org, "clients"))
     end
 
+    # The paths to each of the client json files in the backup
+    #
+    # @param [String] org
+    #
+    # @return [Array]
+    #
     def client_names(org)
       Dir[::File.join(clients_path(org), "*")].map { |dir| ::File.basename(dir, ".json") }
     end
 
+    # The path to groups directory in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def groups_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org, "groups"))
     end
 
+    # The path to acls directory in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def org_acls_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org, "acls"))
     end
 
+    # The path to user_acls directory in the backup
+    #
+    # @return [String]
+    #
     def user_acls_path
       @user_acls_path ||= ::File.expand_path(::File.join(@backup_path, "user_acls"))
     end
 
+    # The path to cookbooks directory in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def cookbooks_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org, "cookbooks"))
     end
 
+    # The path to roles directory in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def roles_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org, "roles"))
     end
 
+    # The path to the org directory in the backup
+    #
+    # @param [String] org
+    #
+    # @return [String]
+    #
     def org_path(org)
       ::File.expand_path(::File.join(@backup_path, "organizations", org))
     end
 
+    #
+    # @return [String]
+    #
     def unique_email
       (0...8).map { (65 + rand(26)).chr }.join.downcase +
         "@" + (0...8).map { (65 + rand(26)).chr }.join.downcase + ".com"
@@ -80,6 +144,16 @@ class Chef
       end
     end
 
+    #
+    # Determine the cookbook name from path
+    #
+    # @param [String] path The path of the cookbook.
+    #
+    # @return [String] The cookbook's name
+    #
+    # @example
+    # cookbook_version_from_path('/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4') => 'chef-sugar'
+    #
     def cookbook_name_from_path(path)
       ::File.basename(path, "-*")
     end

--- a/lib/chef/tidy_substitutions.rb
+++ b/lib/chef/tidy_substitutions.rb
@@ -28,12 +28,6 @@ class Chef
       FileUtils.cp(bp, ::File.join(Dir.pwd, "substitutions.json"))
     end
 
-    def cookbook_version_from_path(path)
-      components = path.split(File::SEPARATOR)
-      name_version = components[components.index("cookbooks") + 1]
-      name_version.match(/\d+\.\d+\.\d+/).to_s
-    end
-
     def revert
     end
 
@@ -68,7 +62,7 @@ class Chef
             @data[entry][glob].each do |substitution|
               search = Regexp.new(substitution["pattern"])
               replace = substitution["replace"].dup
-              replace.gsub!(/\!COOKBOOK_VERSION\!/) { |_m| "'" + cookbook_version_from_path(file) + "'" }
+              replace.gsub!(/\!COOKBOOK_VERSION\!/) { |_m| "'" + @tidy.cookbook_version_from_path(file) + "'" }
               sub_in_file(file, search, replace)
             end
           end

--- a/spec/chef/tidy_common_spec.rb
+++ b/spec/chef/tidy_common_spec.rb
@@ -6,13 +6,21 @@ describe Chef::TidyCommon do
 
   context "#cookbook_name_from_path" do
     it "correctly parses the cookbook name from a path" do
-      expect(t.cookbook_name_from_path('/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4')).to eq('chef-sugar')
+      expect(t.cookbook_name_from_path("/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4")).to eq("chef-sugar")
     end
   end
 
   context "#cookbook_version_from_path" do
     it "correctly parses the cookbook version from a path even if org is also named cookbooks" do
-      expect(t.cookbook_version_from_path('/data/chef_backup/snapshots/20191008040001/organizations/cookbooks/cookbooks/chef-sugar-5.0.4')).to eq('5.0.4')
+      expect(t.cookbook_version_from_path("/data/chef_backup/snapshots/20191008040001/organizations/cookbooks/cookbooks/chef-sugar-5.0.4")).to eq("5.0.4")
+    end
+
+    it "correctly parses the cookbook version from a path even if its within the cookbook" do
+      expect(t.cookbook_version_from_path("/data/chef_backup/snapshots/20191008040001/organizations/cookbooks/cookbooks/chef-sugar-5.0.4/files/foo.bar")).to eq("5.0.4")
+    end
+
+    it "correctly parses the cookbook version from a path even if its within the cookbook and is within a cookbooks dir" do
+      expect(t.cookbook_version_from_path("/data/chef_backup/snapshots/20191008040001/organizations/cookbooks/cookbooks/chef-sugar-5.0.4/files/cookbooks/foo.bar")).to eq("5.0.4")
     end
   end
 end

--- a/spec/chef/tidy_common_spec.rb
+++ b/spec/chef/tidy_common_spec.rb
@@ -1,0 +1,18 @@
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
+require "chef/tidy_common"
+
+describe Chef::TidyCommon do
+  let(:t) { Chef::TidyCommon.new("/tmp/") }
+
+  context "#cookbook_name_from_path" do
+    it "correctly parses the cookbook name from a path" do
+      expect(t.cookbook_name_from_path('/data/chef_backup/snapshots/20191008040001/organizations/myorg/cookbooks/chef-sugar-5.0.4')).to eq('chef-sugar')
+    end
+  end
+
+  context "#cookbook_version_from_path" do
+    it "correctly parses the cookbook version from a path even if org is also named cookbooks" do
+      expect(t.cookbook_version_from_path('/data/chef_backup/snapshots/20191008040001/organizations/cookbooks/cookbooks/chef-sugar-5.0.4')).to eq('5.0.4')
+    end
+  end
+end


### PR DESCRIPTION
1) If your org was named "cookbooks" this method would return nil instead of the actual cookbook name
2) It had some overly complex logic to determine the base name of the dir
3) It belonged with the other common helpers
4) Yard is good

I added a unit test for the two common helpers that I'm concerned about, but this is going to require hand validation.