### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -1,4 +1,4 @@
-require "chef/knife/tidy_base"
+require_relative "tidy_base"
 
 class Chef
   class Knife
@@ -8,8 +8,8 @@ class Chef
         require "chef/cookbook/metadata"
         require "chef/role"
         require "chef/run_list"
-        require "chef/tidy_substitutions"
-        require "chef/tidy_acls"
+        require_relative "../tidy_substitutions"
+        require_relative "../tidy_acls"
         require "ffi_yajl"
         require "fileutils"
         require "securerandom"

--- a/lib/chef/knife/tidy_base.rb
+++ b/lib/chef/knife/tidy_base.rb
@@ -24,8 +24,8 @@ class Chef
       def self.included(includer)
         includer.class_eval do
           deps do
-            require "chef/tidy_server"
-            require "chef/tidy_common"
+            require_relative "../tidy_server"
+            require_relative "../tidy_common"
           end
 
           option :org_list,

--- a/lib/chef/knife/tidy_notify.rb
+++ b/lib/chef/knife/tidy_notify.rb
@@ -1,4 +1,4 @@
-require "chef/knife/tidy_base"
+require_relative "tidy_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/tidy_server_clean.rb
+++ b/lib/chef/knife/tidy_server_clean.rb
@@ -1,4 +1,4 @@
-require "chef/knife/tidy_base"
+require_relative "tidy_base"
 
 class Chef
   class Knife

--- a/lib/chef/knife/tidy_server_report.rb
+++ b/lib/chef/knife/tidy_server_report.rb
@@ -1,4 +1,4 @@
-require "chef/knife/tidy_base"
+require_relative "tidy_base"
 
 class Chef
   class Knife


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>