### PR TITLE
knife-tidy override runlist warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 # Summary
 
+WARNING: If you use `chef-client -o RUNLIST` a lot, this tool is not compatible with that usage. The main way that knife-tidy decides whether it is safe to delete cookbooks is by reading the runlists of all nodes in the chef server. If knife-tidy does not find a certain cookbook or cookbook version in any runlist, it considers that object a deletion candidate. When you regularly use override runlists, those cookbooks are never stored in a node runlist on the chef server. Knife-tidy will never find them and exclude them from deletion.
+
 NOTE: If you're a first-time or inexperienced knife-tidy user, we recommend you read through this blogpost before proceeding with the rest of this documentation: https://blog.chef.io/2017/10/16/migrating-chef-server-knife-ec-backup-knife-tidy/
 
 This Chef Knife plugin provides:


### PR DESCRIPTION
knife-tidy excludes cookbooks in runlists from deletion.

Cookbooks exclusively used in override runlists will not appear in a runlist, and will be considered candidates for deletion by knife-tidy.
Warn about this edge case.

Signed-off-by: <sean_horn@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
