### PR TITLE
Add an option to retain a minimum number of versions of a cookbook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ group :debug do
   gem "pry-stack_explorer"
 end
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
+  gem "chef-zero", "~> 14"
+end
+
 group :development do
   gem "aruba"
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,6 @@ group :debug do
   gem "pry-stack_explorer"
 end
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
-  gem "chef-zero", "~> 14"
-end
-
 group :development do
   gem "aruba"
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ tidy these unused objects up!
   * `--node-threshold NUM_DAYS`
     Maximum number of days since last checkin before node is considered stale (default: 30)
 
+  * `--keep_versions MIN`
+    Minimum number of versions of each cookbook to keep (default: 0)
+
 Example:
 ```bash
 knife tidy server report --orgs brewinc,acmeinc --node-threshold 50


### PR DESCRIPTION
Name the option keep-versions

Signed-off-by: markgibbons <mark.gibbons@nordstrom.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
knife tidy does too good of a job of cleaning up cookbooks.  I'd like an option that lets me keep some of the the most recent versions.  Allows for edge cases like the cookbook was uploaded but has not been used yet or the cookbook is used in unregistered vagrant images but not by a registered node or pinned in an environment. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
