### PR TITLE
FFI_Yajl shared parsing API with exception handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,11 @@ group :development do
   else
     gem "chef"
   end
-  gem "chef-zero"
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
+    gem "chef-zero", "~> 14"
+  else
+    gem "chef-zero"
+  end
   gem "chefstyle", git: "https://github.com/chef/chefstyle.git"
   gem "fakefs"
   gem "rake"

--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -75,7 +75,7 @@ class Chef
         tidy.global_user_names.each do |user|
           email = ""
           ui.stdout.puts "INFO: Validating #{user}"
-          the_user = tidy.json_file_to_hash(File.join(tidy.users_path, "#{user}.json"))
+          the_user = tidy.json_file_to_hash(File.join(tidy.users_path, "#{user}.json"), symbolize_names: false)
           if the_user.key?("email") && the_user["email"].match(/\A[^@\s]+@[^@\s]+\z/)
             if emails_seen.include?(the_user["email"])
               ui.stdout.puts "REPAIRING: Already saw #{user}'s email, creating a unique one."
@@ -147,7 +147,7 @@ class Chef
             add_cookbook_name_to_metadata(cookbook_name, rb_path) if lines.empty?
           else
             if ::File.exist?(json_path)
-              metadata = tidy.json_file_to_hash(json_path)
+              metadata = tidy.json_file_to_hash(json_path, symbolize_names: false)
               if metadata["name"] != cookbook_name
                 metadata["name"] = cookbook_name
                 ui.stdout.puts "REPAIRING: Correcting `name` in #{json_path}`"
@@ -227,7 +227,7 @@ class Chef
 
       def fix_metadata_fields(cookbook_path)
         json_path = ::File.join(cookbook_path, "metadata.json")
-        metadata = tidy.json_file_to_hash(json_path)
+        metadata = tidy.json_file_to_hash(json_path, symbolize_names: false)
         md = metadata.dup
         metadata.each_pair do |key, value|
           if value.nil?
@@ -349,7 +349,7 @@ class Chef
       end
 
       def repair_role_run_lists(role_path)
-        the_role = tidy.json_file_to_hash(role_path)
+        the_role = tidy.json_file_to_hash(role_path, symbolize_names: false)
         new_role = the_role.clone
         rl = Chef::RunList.new
         new_role["run_list"] = []
@@ -382,7 +382,7 @@ class Chef
         for_each_role(org) do |role_path|
           ui.stdout.puts "INFO: Validating Role at #{role_path}"
           begin
-            Chef::Role.from_hash(tidy.json_file_to_hash(role_path))
+            Chef::Role.from_hash(tidy.json_file_to_hash(role_path, symbolize_names: false))
           rescue ArgumentError
             repair_role_run_lists(role_path)
           end
@@ -392,7 +392,7 @@ class Chef
       def validate_clients_group(org)
         ui.stdout.puts "INFO: validating all clients for org #{org} exist in clients group"
         clients_group_path = ::File.join(tidy.groups_path(org), "clients.json")
-        existing_group_data = tidy.json_file_to_hash(clients_group_path)
+        existing_group_data = tidy.json_file_to_hash(clients_group_path, symbolize_names: false)
         existing_group_data["clients"] = [] unless existing_group_data.key?("clients")
         if existing_group_data["clients"].length != tidy.client_names(org).length
           ui.stdout.puts "REPAIRING: Adding #{(existing_group_data["clients"].length - tidy.client_names(org).length).abs} missing clients into #{org}'s client group file #{clients_group_path}"
@@ -406,7 +406,7 @@ class Chef
       def validate_invitations(org)
         invite_file = tidy.invitations_path(org)
         ui.stdout.puts "INFO: validating org #{org} invites in #{invite_file}"
-        invitations = tidy.json_file_to_hash(invite_file)
+        invitations = tidy.json_file_to_hash(invite_file, symbolize_names: false)
         invitations_new = []
         invitations.each do |invite|
           if invite["username"].nil?

--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -75,7 +75,7 @@ class Chef
         tidy.global_user_names.each do |user|
           email = ""
           ui.stdout.puts "INFO: Validating #{user}"
-          the_user = FFI_Yajl::Parser.parse(::File.read(::File.join(tidy.users_path, "#{user}.json")), symbolize_names: false)
+          the_user = tidy.json_file_to_hash(File.join(tidy.users_path, "#{user}.json"))
           if the_user.key?("email") && the_user["email"].match(/\A[^@\s]+@[^@\s]+\z/)
             if emails_seen.include?(the_user["email"])
               ui.stdout.puts "REPAIRING: Already saw #{user}'s email, creating a unique one."
@@ -147,7 +147,7 @@ class Chef
             add_cookbook_name_to_metadata(cookbook_name, rb_path) if lines.empty?
           else
             if ::File.exist?(json_path)
-              metadata = FFI_Yajl::Parser.parse(::File.read(json_path), symbolize_names: false)
+              metadata = tidy.json_file_to_hash(json_path)
               if metadata["name"] != cookbook_name
                 metadata["name"] = cookbook_name
                 ui.stdout.puts "REPAIRING: Correcting `name` in #{json_path}`"
@@ -227,7 +227,7 @@ class Chef
 
       def fix_metadata_fields(cookbook_path)
         json_path = ::File.join(cookbook_path, "metadata.json")
-        metadata = FFI_Yajl::Parser.parse(::File.read(json_path), symbolize_names: false)
+        metadata = tidy.json_file_to_hash(json_path)
         md = metadata.dup
         metadata.each_pair do |key, value|
           if value.nil?
@@ -349,7 +349,7 @@ class Chef
       end
 
       def repair_role_run_lists(role_path)
-        the_role = FFI_Yajl::Parser.parse(::File.read(role_path), symbolize_names: false)
+        the_role = tidy.json_file_to_hash(role_path)
         new_role = the_role.clone
         rl = Chef::RunList.new
         new_role["run_list"] = []
@@ -382,7 +382,7 @@ class Chef
         for_each_role(org) do |role_path|
           ui.stdout.puts "INFO: Validating Role at #{role_path}"
           begin
-            Chef::Role.from_hash(FFI_Yajl::Parser.parse(::File.read(role_path), symbolize_names: false))
+            Chef::Role.from_hash(tidy.json_file_to_hash(role_path))
           rescue ArgumentError
             repair_role_run_lists(role_path)
           end
@@ -392,7 +392,7 @@ class Chef
       def validate_clients_group(org)
         ui.stdout.puts "INFO: validating all clients for org #{org} exist in clients group"
         clients_group_path = ::File.join(tidy.groups_path(org), "clients.json")
-        existing_group_data = FFI_Yajl::Parser.parse(::File.read(clients_group_path), symbolize_names: false)
+        existing_group_data = tidy.json_file_to_hash(clients_group_path)
         existing_group_data["clients"] = [] unless existing_group_data.key?("clients")
         if existing_group_data["clients"].length != tidy.client_names(org).length
           ui.stdout.puts "REPAIRING: Adding #{(existing_group_data["clients"].length - tidy.client_names(org).length).abs} missing clients into #{org}'s client group file #{clients_group_path}"
@@ -406,7 +406,7 @@ class Chef
       def validate_invitations(org)
         invite_file = tidy.invitations_path(org)
         ui.stdout.puts "INFO: validating org #{org} invites in #{invite_file}"
-        invitations = FFI_Yajl::Parser.parse(::File.read(invite_file), symbolize_names: false)
+        invitations = tidy.json_file_to_hash(invite_file)
         invitations_new = []
         invitations.each do |invite|
           if invite["username"].nil?

--- a/lib/chef/knife/tidy_notify.rb
+++ b/lib/chef/knife/tidy_notify.rb
@@ -88,7 +88,7 @@ class Chef
               file_name = "#{reports_dir}/#{org}#{report}"
               ui.info("  Parsing file #{file_name}")
               json_string = File.read(file_name)
-              reports[org][report] = tidy.json_file_to_hash(json_string)
+              reports[org][report] = tidy.json_file_to_hash(json_string, symbolize_names: false)
             rescue Errno::ENOENT
               ui.info("    Skipping file #{file_name} - not found for organization #{org}")
               reports[org][report] = {}

--- a/lib/chef/knife/tidy_notify.rb
+++ b/lib/chef/knife/tidy_notify.rb
@@ -88,7 +88,7 @@ class Chef
               file_name = "#{reports_dir}/#{org}#{report}"
               ui.info("  Parsing file #{file_name}")
               json_string = File.read(file_name)
-              reports[org][report] = FFI_Yajl::Parser.parse(json_string)
+              reports[org][report] = tidy.json_file_to_hash(json_string)
             rescue Errno::ENOENT
               ui.info("    Skipping file #{file_name} - not found for organization #{org}")
               reports[org][report] = {}

--- a/lib/chef/knife/tidy_server_clean.rb
+++ b/lib/chef/knife/tidy_server_clean.rb
@@ -91,7 +91,7 @@ class Chef
         return unless ::File.exist?(unused_cookbooks_file)
 
         ui.stdout.puts "INFO: Cleaning cookbooks for Org: #{org}, using #{unused_cookbooks_file}"
-        unused_cookbooks = FFI_Yajl::Parser.parse(::File.read(unused_cookbooks_file), symbolize_names: true)
+        unused_cookbooks = tidy.json_file_to_hash(unused_cookbooks_file, true)
         unused_cookbooks.keys.each do |cookbook|
           versions = unused_cookbooks[cookbook]
           versions.each do |version|
@@ -118,7 +118,7 @@ class Chef
         return unless ::File.exist?(stale_nodes_file)
 
         ui.stdout.puts "INFO: Cleaning stale nodes for Org: #{org}, using #{stale_nodes_file}"
-        stale_nodes = FFI_Yajl::Parser.parse(::File.read(stale_nodes_file), symbolize_names: true)
+        stale_nodes = tidy.json_file_to_hash(stale_nodes_file, true)
         stale_nodes[:list].each do |node|
           queue << -> { delete_node_job(org, node) }
         end

--- a/lib/chef/knife/tidy_server_clean.rb
+++ b/lib/chef/knife/tidy_server_clean.rb
@@ -91,7 +91,7 @@ class Chef
         return unless ::File.exist?(unused_cookbooks_file)
 
         ui.stdout.puts "INFO: Cleaning cookbooks for Org: #{org}, using #{unused_cookbooks_file}"
-        unused_cookbooks = tidy.json_file_to_hash(unused_cookbooks_file, true)
+        unused_cookbooks = tidy.json_file_to_hash(unused_cookbooks_file, symbolize_names: true)
         unused_cookbooks.keys.each do |cookbook|
           versions = unused_cookbooks[cookbook]
           versions.each do |version|
@@ -118,7 +118,7 @@ class Chef
         return unless ::File.exist?(stale_nodes_file)
 
         ui.stdout.puts "INFO: Cleaning stale nodes for Org: #{org}, using #{stale_nodes_file}"
-        stale_nodes = tidy.json_file_to_hash(stale_nodes_file, true)
+        stale_nodes = tidy.json_file_to_hash(stale_nodes_file, symbolize_names: true)
         stale_nodes[:list].each do |node|
           queue << -> { delete_node_job(org, node) }
         end

--- a/lib/chef/tidy_acls.rb
+++ b/lib/chef/tidy_acls.rb
@@ -20,26 +20,26 @@ class Chef
     def load_users
       @tidy.ui.stdout.puts "INFO: Loading users"
       Dir[::File.join(@tidy.users_path, "*.json")].each do |user|
-        @users.push(@tidy.json_file_to_hash(user, true))
+        @users.push(@tidy.json_file_to_hash(user, symbolize_names: true))
       end
     end
 
     def load_members
       @tidy.ui.stdout.puts "INFO: Loading members for #{@org}"
-      @members = @tidy.json_file_to_hash(@tidy.members_path(@org), true)
+      @members = @tidy.json_file_to_hash(@tidy.members_path(@org), symbolize_names: true)
     end
 
     def load_clients
       @tidy.ui.stdout.puts "INFO: Loading clients for #{@org}"
       Dir[::File.join(@tidy.clients_path(@org), "*.json")].each do |client|
-        @clients.push(@tidy.json_file_to_hash(client, true))
+        @clients.push(@tidy.json_file_to_hash(client, symbolize_names: true))
       end
     end
 
     def load_groups
       @tidy.ui.stdout.puts "INFO: Loading groups for #{@org}"
       Dir[::File.join(@tidy.groups_path(@org), "*.json")].each do |group|
-        @groups.push(@tidy.json_file_to_hash(group, true))
+        @groups.push(@tidy.json_file_to_hash(group, symbolize_names: true))
       end
     end
 
@@ -128,7 +128,7 @@ class Chef
 
     def remove_group_from_acl(group, acl_file)
       @tidy.ui.stdout.puts "REPAIRING: Removing invalid group: #{group} from #{acl_file}"
-      acl = @tidy.json_file_to_hash(acl_file)
+      acl = @tidy.json_file_to_hash(acl_file, symbolize_names: false)
       acl_ops.each do |op|
         acl[op]["groups"].reject! { |the_group| the_group == group }
       end
@@ -137,7 +137,7 @@ class Chef
 
     # Appends the proper acls for ::server-admins and the org's read access group if they are missing.
     def ensure_global_group_acls(acl_file)
-      acl = @tidy.json_file_to_hash(acl_file)
+      acl = @tidy.json_file_to_hash(acl_file, symbolize_names: false)
       acl_ops.each do |op|
         unless acl[op]["groups"].include? "::server-admins"
           @tidy.ui.stdout.puts "REPAIRING: Adding #{op} acl for ::server-admins in #{acl_file}"
@@ -152,7 +152,7 @@ class Chef
     end
 
     def ensure_client_read_acls(acl_file)
-      acl = @tidy.json_file_to_hash(acl_file)
+      acl = @tidy.json_file_to_hash(acl_file, symbolize_names: false)
       %w{users admins}.each do |group|
         unless acl["read"]["groups"].include? group
           @tidy.ui.stdout.puts "REPAIRING: Adding read acl for #{group} in #{acl_file}"
@@ -164,7 +164,7 @@ class Chef
 
     def validate_acls
       org_acls.each do |acl_file|
-        acl = @tidy.json_file_to_hash(acl_file)
+        acl = @tidy.json_file_to_hash(acl_file, symbolize_names: false)
         actors_groups = acl_actors_groups(acl)
         actors_groups[:actors].each do |actor|
           next if actor == "pivotal"
@@ -203,11 +203,11 @@ class Chef
       @members.each do |member|
         user_acl_path = ::File.join(@tidy.user_acls_path, "#{member[:user][:username]}.json")
         begin
-          user_acl = @tidy.json_file_to_hash(user_acl_path)
+          user_acl = @tidy.json_file_to_hash(user_acl_path, symbolize_names: false)
         rescue Errno::ENOENT
           @tidy.ui.stdout.puts "REPAIRING: Replacing missing user acl for #{member[:user][:username]}."
           @tidy.write_new_file(default_user_acl(member), user_acl_path, backup = false)
-          user_acl = @tidy.json_file_to_hash(user_acl_path)
+          user_acl = @tidy.json_file_to_hash(user_acl_path, symbolize_names: false)
         end
         ensure_global_group_acls(user_acl_path)
         actors_groups = acl_actors_groups(user_acl)
@@ -221,11 +221,11 @@ class Chef
       @clients.each do |client|
         client_acl_path = ::File.join(@tidy.org_acls_path(@org), "clients", "#{client[:name]}.json")
         begin
-          client_acl = @tidy.json_file_to_hash(client_acl_path)
+          client_acl = @tidy.json_file_to_hash(client_acl_path, symbolize_names: false)
         rescue Errno::ENOENT
           @tidy.ui.stdout.puts "REPAIRING: Replacing missing client acl for #{client[:name]} in #{client_acl_path}."
           @tidy.write_new_file(default_client_acl(client[:name]), client_acl_path, backup = false)
-          client_acl = @tidy.json_file_to_hash(client_acl_path)
+          client_acl = @tidy.json_file_to_hash(client_acl_path, symbolize_names: false)
         end
         ensure_client_read_acls(client_acl_path)
       end

--- a/lib/chef/tidy_acls.rb
+++ b/lib/chef/tidy_acls.rb
@@ -20,26 +20,26 @@ class Chef
     def load_users
       @tidy.ui.stdout.puts "INFO: Loading users"
       Dir[::File.join(@tidy.users_path, "*.json")].each do |user|
-        @users.push(FFI_Yajl::Parser.parse(::File.read(user), symbolize_names: true))
+        @users.push(@tidy.json_file_to_hash(user, true))
       end
     end
 
     def load_members
       @tidy.ui.stdout.puts "INFO: Loading members for #{@org}"
-      @members = FFI_Yajl::Parser.parse(::File.read(@tidy.members_path(@org)), symbolize_names: true)
+      @members = @tidy.json_file_to_hash(@tidy.members_path(@org), true)
     end
 
     def load_clients
       @tidy.ui.stdout.puts "INFO: Loading clients for #{@org}"
       Dir[::File.join(@tidy.clients_path(@org), "*.json")].each do |client|
-        @clients.push(FFI_Yajl::Parser.parse(::File.read(client), symbolize_names: true))
+        @clients.push(@tidy.json_file_to_hash(client, true))
       end
     end
 
     def load_groups
       @tidy.ui.stdout.puts "INFO: Loading groups for #{@org}"
       Dir[::File.join(@tidy.groups_path(@org), "*.json")].each do |group|
-        @groups.push(FFI_Yajl::Parser.parse(::File.read(group), symbolize_names: true))
+        @groups.push(@tidy.json_file_to_hash(group, true))
       end
     end
 
@@ -128,7 +128,7 @@ class Chef
 
     def remove_group_from_acl(group, acl_file)
       @tidy.ui.stdout.puts "REPAIRING: Removing invalid group: #{group} from #{acl_file}"
-      acl = FFI_Yajl::Parser.parse(::File.read(acl_file), symbolize_names: false)
+      acl = @tidy.json_file_to_hash(acl_file)
       acl_ops.each do |op|
         acl[op]["groups"].reject! { |the_group| the_group == group }
       end
@@ -137,7 +137,7 @@ class Chef
 
     # Appends the proper acls for ::server-admins and the org's read access group if they are missing.
     def ensure_global_group_acls(acl_file)
-      acl = FFI_Yajl::Parser.parse(::File.read(acl_file), symbolize_names: false)
+      acl = @tidy.json_file_to_hash(acl_file)
       acl_ops.each do |op|
         unless acl[op]["groups"].include? "::server-admins"
           @tidy.ui.stdout.puts "REPAIRING: Adding #{op} acl for ::server-admins in #{acl_file}"
@@ -152,7 +152,7 @@ class Chef
     end
 
     def ensure_client_read_acls(acl_file)
-      acl = FFI_Yajl::Parser.parse(::File.read(acl_file), symbolize_names: false)
+      acl = @tidy.json_file_to_hash(acl_file)
       %w{users admins}.each do |group|
         unless acl["read"]["groups"].include? group
           @tidy.ui.stdout.puts "REPAIRING: Adding read acl for #{group} in #{acl_file}"
@@ -164,7 +164,7 @@ class Chef
 
     def validate_acls
       org_acls.each do |acl_file|
-        acl = FFI_Yajl::Parser.parse(::File.read(acl_file), symbolize_names: false)
+        acl = @tidy.json_file_to_hash(acl_file)
         actors_groups = acl_actors_groups(acl)
         actors_groups[:actors].each do |actor|
           next if actor == "pivotal"
@@ -203,11 +203,11 @@ class Chef
       @members.each do |member|
         user_acl_path = ::File.join(@tidy.user_acls_path, "#{member[:user][:username]}.json")
         begin
-          user_acl = FFI_Yajl::Parser.parse(::File.read(user_acl_path), symbolize_names: false)
+          user_acl = @tidy.json_file_to_hash(user_acl_path)
         rescue Errno::ENOENT
           @tidy.ui.stdout.puts "REPAIRING: Replacing missing user acl for #{member[:user][:username]}."
           @tidy.write_new_file(default_user_acl(member), user_acl_path, backup = false)
-          user_acl = FFI_Yajl::Parser.parse(::File.read(user_acl_path), symbolize_names: false)
+          user_acl = @tidy.json_file_to_hash(user_acl_path)
         end
         ensure_global_group_acls(user_acl_path)
         actors_groups = acl_actors_groups(user_acl)
@@ -221,11 +221,11 @@ class Chef
       @clients.each do |client|
         client_acl_path = ::File.join(@tidy.org_acls_path(@org), "clients", "#{client[:name]}.json")
         begin
-          client_acl = FFI_Yajl::Parser.parse(::File.read(client_acl_path), symbolize_names: false)
+          client_acl = @tidy.json_file_to_hash(client_acl_path)
         rescue Errno::ENOENT
           @tidy.ui.stdout.puts "REPAIRING: Replacing missing client acl for #{client[:name]} in #{client_acl_path}."
           @tidy.write_new_file(default_client_acl(client[:name]), client_acl_path, backup = false)
-          client_acl = FFI_Yajl::Parser.parse(::File.read(client_acl_path), symbolize_names: false)
+          client_acl = @tidy.json_file_to_hash(client_acl_path)
         end
         ensure_client_read_acls(client_acl_path)
       end

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -149,10 +149,10 @@ class Chef
       end
     end
 
-    # Read a json file and return a hash of parsed content with symbolized keys
+    # Read a json file and return a hash of parsed content with optional symbolized keys
     #
     # @param [String] path to file
-    # @param [Bool] symbolize keys true or false, defaults to false
+    # @param [Bool] symbolize keys, defaults to false
     #
     # @return [Hash]
     #

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -152,18 +152,18 @@ class Chef
     # Read a json file and return a hash of parsed content with optional symbolized keys
     #
     # @param [String] path to file
-    # @param [Bool] symbolize keys, defaults to false
+    # @param [double splat] options to pass FFI_Yajl::Parser.parse()
     #
-    # @return [Hash]
+    # @return [Hash] original json content as hash
     #
     # @example
-    # json_file_to_hash('/path/to/file.json', true) => { foo: "bar" }
+    # json_file_to_hash('/path/to/file.json', symbolize_names: true) => { foo: "bar" }
     #
-    def json_file_to_hash(file_path, symbolize = false)
-      FFI_Yajl::Parser.parse(File.read(file_path), symbolize_names: symbolize)
-    rescue Errno::ENOENT, Errno::EACCES, FFI_Yajl::ParseError => e
-      puts "ERROR: unable to parse file: '#{file_path}' #{e}"
-      exit
+    def json_file_to_hash(file_path, **options)
+      FFI_Yajl::Parser.parse(File.read(file_path), options)
+    rescue Errno::ENOENT, Errno::EACCES, FFI_Yajl::ParseError
+      puts "ERROR: unable to parse file: '#{file_path}'"
+      raise
     end
 
     #

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -149,6 +149,23 @@ class Chef
       end
     end
 
+    # Read a json file and return a hash of parsed content with symbolized keys
+    #
+    # @param [String] path to file
+    # @param [Bool] symbolize keys true or false, defaults to false
+    #
+    # @return [Hash]
+    #
+    # @example
+    # json_file_to_hash('/path/to/file.json', true) => { foo: "bar" }
+    #
+    def json_file_to_hash(file_path, symbolize = false)
+      FFI_Yajl::Parser.parse(File.read(file_path), symbolize_names: symbolize)
+    rescue Errno::ENOENT, Errno::EACCES, FFI_Yajl::ParseError => e
+      puts "ERROR: unable to parse file: '#{file_path}' #{e}"
+      exit
+    end
+
     #
     # Determine the cookbook name from path
     #

--- a/lib/chef/tidy_substitutions.rb
+++ b/lib/chef/tidy_substitutions.rb
@@ -17,7 +17,7 @@ class Chef
 
     def load_data
       @tidy.ui.stdout.puts "INFO: Loading substitutions from #{file_path}"
-      @data = @tidy.json_file_to_hash(@file_path)
+      @data = @tidy.json_file_to_hash(@file_path, symbolize_names: false)
     rescue Errno::ENOENT
       raise NoSubstitutionFile, file_path
     end

--- a/lib/chef/tidy_substitutions.rb
+++ b/lib/chef/tidy_substitutions.rb
@@ -17,7 +17,7 @@ class Chef
 
     def load_data
       @tidy.ui.stdout.puts "INFO: Loading substitutions from #{file_path}"
-      @data = FFI_Yajl::Parser.parse(::File.read(@file_path), symbolize_names: false)
+      @data = @tidy.json_file_to_hash(@file_path)
     rescue Errno::ENOENT
       raise NoSubstitutionFile, file_path
     end

--- a/spec/chef/knife/tidy_backup_clean_spec.rb
+++ b/spec/chef/knife/tidy_backup_clean_spec.rb
@@ -18,7 +18,7 @@ describe Chef::Knife::TidyBackupClean do
 
   context "completion_message" do
     it "lets the user know we're Finished" do
-      expect { t.completion_message }.to output("** Finished **\n").to_stdout
+      expect { t.completion_message }.to output("** Finished **\n").to_stdout_from_any_process
     end
   end
 end

--- a/spec/chef/knife/tidy_base_spec.rb
+++ b/spec/chef/knife/tidy_base_spec.rb
@@ -19,7 +19,7 @@ describe Chef::Knife::TidyBase do
 
   context "completion_message" do
     it "lets the user know we're Finished" do
-      expect { t.completion_message }.to output("** Finished **\n").to_stdout
+      expect { t.completion_message }.to output("** Finished **\n").to_stdout_from_any_process
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/chef/knife-tidy/issues/120

Whereas previously there was no indication which file was not valid json, now there is clear and actionable output:
```
ERROR: unable to parse file: '/Users/jmiller/jm01/transfer/Devel/ChefProject/chef-server-vagrant/backups/users/bob.json' lexical error: invalid string in json text.
                                       none
                     (right here) ------^
```

Signed-off-by: Jeremy J. Miller jm@chef.io