### PR TITLE
fix #124 by adding conf dir to gemspec

### DIFF
--- a/knife-tidy.gemspec
+++ b/knife-tidy.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description      = s.summary
   s.homepage         = "https://github.com/chef-customers/knife-tidy"
   s.license          = "Apache-2.0"
-  s.files            = %w{LICENSE} + Dir.glob("lib/**/*")
+  s.files            = %w{LICENSE} + Dir.glob("lib/**/*") + Dir.glob("conf/**/*")
   s.require_paths    = ["lib"]
 
   s.required_ruby_version = ">= 2.3.0"


### PR DESCRIPTION
Signed-off-by: Emir Rios <mskdenigma@gmail.com>

## Description
the gen-gsub command wasn't generating a json because the conf directory wasn't declared in the gemspec

## Related Issue
https://github.com/chef/knife-tidy/issues/124

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
