### PR TITLE
Pin pry-stack-explorer to fix Ruby < 2.6 tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,29 +5,30 @@ gemspec
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer"
+  gem "pry-stack_explorer", "= 0.4.11" # remove this pin when we drop support for Ruby < 2.6
 end
 
 group :development do
   gem "aruba"
-
-  # make sure we can still test on Ruby 2.4
-  if RUBY_VERSION.match?(/2\.4/)
-    gem "chef", "~> 14"
-  else
-    gem "chef"
-  end
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
-    gem "chef-zero", "~> 14"
-  else
-    gem "chef-zero"
-  end
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git"
+  gem "chefstyle"
   gem "fakefs"
   gem "rake"
   gem "rspec"
   gem "simplecov"
   gem "simplecov-console"
+
+  # preserve testing on older ruby releases
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
+    gem "chef-zero", "~> 14"
+    gem "chef", "~> 14"
+    gem "activesupport", "~> 5.0"
+  elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6")
+    gem "chef-zero", "~> 14"
+    gem "chef", "~> 15"
+  else
+    gem "chef-zero"
+    gem "chef"
+  end
 end
 
 group :docs do


### PR DESCRIPTION
This has no impact on the actual app, but it's making our tests fail

Signed-off-by: Tim Smith <tsmith@chef.io>