### PR TITLE
fix #127 by sorting clients.json

### DIFF
--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -397,16 +397,10 @@ class Chef
         if existing_group_data["clients"].length != tidy.client_names(org).length
           ui.stdout.puts "REPAIRING: Adding #{(existing_group_data["clients"].length - tidy.client_names(org).length).abs} missing clients into #{org}'s client group file #{clients_group_path}"
           existing_group_data["clients"] = (existing_group_data["clients"] + tidy.client_names(org)).uniq
-          ::File.open(clients_group_path, "w") do |f|
-            f.write(Chef::JSONCompat.to_json_pretty(existing_group_data))
-          end
         end
-        if existing_group_data["clients"] != existing_group_data["clients"].sort
-          ui.stdout.puts "REPAIRING: Sorting clients into #{org}'s client group file #{clients_group_path}"
-          existing_group_data["clients"] = existing_group_data["clients"].sort
-          ::File.open(clients_group_path, "w") do |f|
-            f.write(Chef::JSONCompat.to_json_pretty(existing_group_data))
-          end
+        existing_group_data["clients"] = existing_group_data["clients"].sort
+        ::File.open(clients_group_path, "w") do |f|
+          f.write(Chef::JSONCompat.to_json_pretty(existing_group_data))
         end
       end
 

--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -401,7 +401,13 @@ class Chef
             f.write(Chef::JSONCompat.to_json_pretty(existing_group_data))
           end
         end
-        existing_group_data = existing_group_data.sort
+        if existing_group_data["clients"] != existing_group_data["clients"].sort
+          ui.stdout.puts "REPAIRING: Sorting clients into #{org}'s client group file #{clients_group_path}"
+          existing_group_data["clients"] = existing_group_data["clients"].sort
+          ::File.open(clients_group_path, "w") do |f|
+            f.write(Chef::JSONCompat.to_json_pretty(existing_group_data))
+          end
+        end
       end
 
       def validate_invitations(org)

--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -401,6 +401,7 @@ class Chef
             f.write(Chef::JSONCompat.to_json_pretty(existing_group_data))
           end
         end
+        existing_group_data = existing_group_data.sort
       end
 
       def validate_invitations(org)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
When you run `knife tidy backup clean` it will now also sort your `groups/clients.json`. You need to sort when restoring a backup from an old chef server backup to a new chef-automate setup as the database has sorted keys that align with client names. This fixes idempotency so that you can rerun restores over and over again without issues.

## Related Issue
https://github.com/chef/knife-tidy/issues/127

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
