### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ rescue LoadError
 end
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."

--- a/lib/chef/knife/tidy_backup_clean.rb
+++ b/lib/chef/knife/tidy_backup_clean.rb
@@ -10,9 +10,9 @@ class Chef
         require "chef/run_list"
         require_relative "../tidy_substitutions"
         require_relative "../tidy_acls"
-        require "ffi_yajl"
-        require "fileutils"
-        require "securerandom"
+        require "ffi_yajl" unless defined?(FFI_Yajl)
+        require "fileutils" unless defined?(FileUtils)
+        require "securerandom" unless defined?(SecureRandom)
       end
 
       banner "knife tidy backup clean (options)"

--- a/lib/chef/knife/tidy_notify.rb
+++ b/lib/chef/knife/tidy_notify.rb
@@ -4,7 +4,7 @@ class Chef
   class Knife
     class TidyNotify < Knife
       deps do
-        require "ffi_yajl"
+        require "ffi_yajl" unless defined?(FFI_Yajl)
         require "net/smtp"
       end
 

--- a/lib/chef/knife/tidy_server_clean.rb
+++ b/lib/chef/knife/tidy_server_clean.rb
@@ -6,7 +6,7 @@ class Chef
       include Knife::TidyBase
 
       deps do
-        require "ffi_yajl"
+        require "ffi_yajl" unless defined?(FFI_Yajl)
         require "chef/util/threaded_job_queue"
       end
 

--- a/lib/chef/knife/tidy_server_report.rb
+++ b/lib/chef/knife/tidy_server_report.rb
@@ -7,7 +7,7 @@ class Chef
       include Knife::TidyBase
 
       deps do
-        require "ffi_yajl"
+        require "ffi_yajl" unless defined?(FFI_Yajl)
       end
 
       banner "knife tidy server report (options)"

--- a/lib/chef/tidy_acls.rb
+++ b/lib/chef/tidy_acls.rb
@@ -1,5 +1,5 @@
-require "ffi_yajl"
-require "fileutils"
+require "ffi_yajl" unless defined?(FFI_Yajl)
+require "fileutils" unless defined?(FileUtils)
 require "chef/log"
 
 class Chef

--- a/lib/chef/tidy_common.rb
+++ b/lib/chef/tidy_common.rb
@@ -1,5 +1,5 @@
-require "ffi_yajl"
-require "fileutils"
+require "ffi_yajl" unless defined?(FFI_Yajl)
+require "fileutils" unless defined?(FileUtils)
 require "chef/knife/core/ui"
 
 class Chef

--- a/lib/chef/tidy_substitutions.rb
+++ b/lib/chef/tidy_substitutions.rb
@@ -1,6 +1,6 @@
-require "ffi_yajl"
-require "tempfile"
-require "fileutils"
+require "ffi_yajl" unless defined?(FFI_Yajl)
+require "tempfile" unless defined?(Tempfile)
+require "fileutils" unless defined?(FileUtils)
 require "chef/log"
 
 class Chef

--- a/spec/chef/knife/tidy_backup_clean_spec.rb
+++ b/spec/chef/knife/tidy_backup_clean_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_hel
 require "chef/knife/tidy_backup_clean"
 require "chef/knife"
 require "chef/config"
-require "stringio"
+require "stringio" unless defined?(StringIO)
 
 class Tester < Chef::Knife
 end

--- a/spec/chef/knife/tidy_base_spec.rb
+++ b/spec/chef/knife/tidy_base_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_hel
 require "chef/knife/tidy_base"
 require "chef/knife"
 require "chef/config"
-require "stringio"
+require "stringio" unless defined?(StringIO)
 
 class Tester < Chef::Knife
   include Chef::Knife::TidyBase


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>