### PR TITLE
Lazy load the chef server API dep

### DIFF
--- a/lib/chef/knife/tidy_base.rb
+++ b/lib/chef/knife/tidy_base.rb
@@ -16,7 +16,6 @@
 #
 
 require "chef/knife"
-require "chef/server_api"
 
 class Chef
   class Knife
@@ -24,6 +23,7 @@ class Chef
       def self.included(includer)
         includer.class_eval do
           deps do
+            require "chef/server_api"
             require_relative "../tidy_server"
             require_relative "../tidy_common"
           end


### PR DESCRIPTION
This removes 2 total requires when running `knife -h`

Signed-off-by: Tim Smith <tsmith@chef.io>