### PR TITLE
Move syslog dependency from Gemfile to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :development do
     gem "fakefs"
   else
     gem "net-smtp"
-    gem "syslog"
     gem "contracts", "~> 0.17.2"
     gem "chef-zero"
     gem "chef", "~> 18"

--- a/knife-tidy.gemspec
+++ b/knife-tidy.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |s|
   s.require_paths    = ["lib"]
 
   s.required_ruby_version = ">= 2.7.0"
+
+  s.add_dependency "syslog", "~> 0.3"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
In Ruby 3.4, syslog is no longer part of the stdlib and must be declared explicitly. Moved syslog from the Gemfile to the gemspec so it is always installed as a runtime dependency

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
