### PR TITLE
Remove Ruby version conditional for syslog dependency

### DIFF
--- a/knife-tidy.gemspec
+++ b/knife-tidy.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  # This gem was removed from the Ruby standard library starting with version 3.4
-  # See: https://stdgems.org/new-in/3.4
+  # syslog was removed from Ruby's standard library in 3.4; see https://stdgems.org/new-in/3.4
   s.add_dependency "syslog", "~> 0.3"
 end


### PR DESCRIPTION
Unconditionally add syslog dependency in gemspec. This fixes the issue where Ruby version conditionals in gemspec do not work for install time. See https://github.com/chef/knife-tidy/pull/152#r2340499141 for context.